### PR TITLE
chore(deps): bump brace-expansion and postcss overrides to clear audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4340,9 +4340,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7084,9 +7084,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -7380,9 +7380,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
-      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -7399,7 +7399,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -56,9 +56,9 @@
   "overrides": {
     "serialize-javascript": "^7.0.5",
     "lodash": "^4.17.24",
-    "postcss": "^8.5.24",
+    "postcss": "^8.5.26",
     "fast-uri": "^3.1.5",
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "workbox-build": "7.4.0",
     "@babel/plugin-transform-modules-systemjs": "^7.29.4"
   }


### PR DESCRIPTION
Clears the two remaining high-severity findings. `npm audit` now reports **0 vulnerabilities**.

| Override | Change | Advisory |
|---|---|---|
| `brace-expansion` | `^5.0.8` → `^5.0.9` | GHSA-rgw5-rvv9-x895 — DoS via unbounded intermediate arrays |
| `postcss` | `^8.5.24` → `^8.5.26` | GHSA-2v37-7h3g-55p8 — `nanoid` infinite loop |

The `brace-expansion` advisory is new and specifically **bypasses the CVE-2026-14257 mitigation** that the previous `^5.0.8` pin relied on, so the old pin no longer helps.

For `nanoid`, no separate override was added: `postcss` 8.5.26 already requires `nanoid ^3.3.17`, so bumping postcss resolves it transitively. Confirmed with `npm ls nanoid` — resolves to 3.3.18.

## Verification

- `npm audit` — **0 vulnerabilities**
- `npm run lint` — clean
- `npm run test:run` — 22/22 passing
- `npm run build` — succeeds, service worker generated (exercises the workbox → minimatch → brace-expansion path)