### PR TITLE
feat(ui): keep brand icons locally and upgrade lucide-react to v1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.43.0",
-        "lucide-react": "^0.462.0",
+        "lucide-react": "^1.31.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-helmet-async": "^3.0.0",
@@ -6987,12 +6987,12 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.462.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.462.0.tgz",
-      "integrity": "sha512-NTL7EbAao9IFtuSivSZgrAh4fZd09Lr+6MTkqIxuHaH2nnYiYIzXPo06cOxHg9wKLdj6LL8TByG4qpePqwgx/g==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.31.0.tgz",
+      "integrity": "sha512-G8u2eEtoHUnUa9f8lbvqDhCiORMnYLdUEo06EEG9MQvHQrInKcX3Pa2TH39MM5qyzRcWETxB0+aOwAPI1g1kEg==",
       "license": "ISC",
       "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.43.0",
-    "lucide-react": "^0.462.0",
+    "lucide-react": "^1.31.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-helmet-async": "^3.0.0",

--- a/src/components/resume/Hero.tsx
+++ b/src/components/resume/Hero.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/ui/button';
-import { Github, Linkedin, Mail } from 'lucide-react';
+import { Mail } from 'lucide-react';
+import { GithubIcon, LinkedinIcon } from '@/components/ui/BrandIcons';
 import portfolioData from '@/data/portfolio.json';
 
 const { personal } = portfolioData;
@@ -52,7 +53,7 @@ const Hero = () => {
             className="text-gray-400 hover:text-blue-400 transition-colors duration-300 hover:scale-110 transform"
             aria-label="Visit GitHub profile (opens in new tab)"
           >
-            <Github className="w-6 h-6" aria-hidden="true" />
+            <GithubIcon className="w-6 h-6" aria-hidden="true" />
           </a>
           <a
             href={personal.social.linkedin}
@@ -61,7 +62,7 @@ const Hero = () => {
             className="text-gray-400 hover:text-blue-400 transition-colors duration-300 hover:scale-110 transform"
             aria-label="Visit LinkedIn profile (opens in new tab)"
           >
-            <Linkedin className="w-6 h-6" aria-hidden="true" />
+            <LinkedinIcon className="w-6 h-6" aria-hidden="true" />
           </a>
           <a
             href={personal.social.email}

--- a/src/components/resume/Portfolio.tsx
+++ b/src/components/resume/Portfolio.tsx
@@ -2,7 +2,8 @@
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { ExternalLink, Github, Filter, ChevronDown, Check } from 'lucide-react';
+import { ExternalLink, Filter, ChevronDown, Check } from 'lucide-react';
+import { GithubIcon } from '@/components/ui/BrandIcons';
 import { useAppStore } from '@/store/useAppStore';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useState, useRef, useEffect } from 'react';
@@ -207,7 +208,7 @@ const Portfolio = () => {
                           className="border-gray-600 text-gray-300 hover:bg-gray-700"
                           onClick={() => window.open(project.githubUrl, '_blank')}
                         >
-                          <Github className="w-4 h-4 mr-2" />
+                          <GithubIcon className="w-4 h-4 mr-2" />
                           Code
                         </Button>
                       )}
@@ -224,7 +225,7 @@ const Portfolio = () => {
             className="bg-blue-600 hover:bg-blue-700 text-white px-8 py-3"
             onClick={() => window.open('https://github.com/luismiguelopes', '_blank')}
           >
-            <Github className="w-4 h-4 mr-2" />
+            <GithubIcon className="w-4 h-4 mr-2" />
             View All Projects on GitHub
           </Button>
         </div>

--- a/src/components/resume/__tests__/Hero.test.tsx
+++ b/src/components/resume/__tests__/Hero.test.tsx
@@ -44,5 +44,10 @@ describe('Hero Component', () => {
     
     expect(githubLink).toHaveAttribute('href', 'https://github.com/luismiguelopes/')
     expect(linkedinLink).toHaveAttribute('href', 'https://www.linkedin.com/in/luismiguelopes/')
+
+    // Os ícones de marca são locais (lucide-react removeu-os no v1), por isso
+    // confirma-se que cada link renderiza mesmo o seu SVG
+    expect(githubLink?.querySelector('svg')).toBeInTheDocument()
+    expect(linkedinLink?.querySelector('svg')).toBeInTheDocument()
   })
 })

--- a/src/components/ui/BrandIcons.tsx
+++ b/src/components/ui/BrandIcons.tsx
@@ -1,0 +1,44 @@
+import type { SVGProps } from 'react';
+
+/**
+ * Brand icons kept locally.
+ *
+ * lucide-react removed all brand/logo icons in v1 (trademark reasons), so
+ * `Github` and `Linkedin` no longer exist upstream. These reproduce the v0.462
+ * artwork verbatim so the social links keep the stroke style of the other
+ * icons — an official brand set would be solid-filled and look out of place.
+ *
+ * Path data from lucide-react v0.462.0, ISC licensed:
+ * https://github.com/lucide-icons/lucide/blob/main/LICENSE
+ */
+
+const defaultProps: SVGProps<SVGSVGElement> = {
+  xmlns: 'http://www.w3.org/2000/svg',
+  width: 24,
+  height: 24,
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 2,
+  strokeLinecap: 'round',
+  strokeLinejoin: 'round',
+};
+
+export function GithubIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg {...defaultProps} {...props}>
+      <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
+      <path d="M9 18c-4.51 2-5-2-7-2" />
+    </svg>
+  );
+}
+
+export function LinkedinIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg {...defaultProps} {...props}>
+      <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z" />
+      <rect width="4" height="12" x="2" y="9" />
+      <circle cx="4" cy="4" r="2" />
+    </svg>
+  );
+}


### PR DESCRIPTION
Unblocks the `lucide-react` v1 upgrade that #38 could not land.

## The problem

lucide-react removed **all brand/logo icons** in v1 for trademark reasons. `Github` and `Linkedin` no longer exist upstream, so importing them resolved to `undefined` and broke rendering:

```
Error: Element type is invalid: expected a string ... but got: undefined.
Check the render method of `Hero`.
```

That is why #38 failed CI with 13 broken tests. It is not a rename — there is no replacement in the v1 set (`GitBranch`, `GitFork` and friends are version-control concepts, not the logos).

Affected: `Hero.tsx:55,64` (social links) and `Portfolio.tsx:210,227` ("Code" buttons).

## The fix

New `src/components/ui/BrandIcons.tsx` with `GithubIcon` and `LinkedinIcon`, reproducing the v0.462 artwork verbatim. Path data is ISC licensed and attributed in the file header.

Two deliberate choices:

- **Local SVG rather than a brand-icon package.** `simple-icons` and similar ship solid-filled logos, which would clash with the 15 stroke-style lucide icons the site still uses. Reusing the original paths keeps the row visually consistent.
- **Components spread `SVGProps<SVGSVGElement>`**, so they are drop-in. Existing `className="w-6 h-6"` and `aria-hidden="true"` usage is untouched.

Rendered markup is identical to what lucide v0.462 produced — same attributes, same paths:

```html
<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
     fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
     stroke-linejoin="round" class="w-6 h-6" aria-hidden="true">…</svg>
```

## Test improvement

The Hero social-links test only asserted `href` values, so the icon regression surfaced as an unrelated render crash rather than a clear failure. It now also asserts each link renders its `<svg>`. Confirmed the assertion is meaningful by temporarily removing an icon — the test fails as intended.

## Verification

- `npm run lint` — clean
- `npm run test:run` — 22/22 passing
- `npm run build` — succeeds
- `npm audit` — 0 vulnerabilities
- Confirmed all 15 remaining lucide icons still exist in v1

Closes #38.